### PR TITLE
Update configs vars in Windows config

### DIFF
--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,4 +1,4 @@
 ---
-WorkingDirectory: "C:\\Program Files\\Bacula\\working"
-PidDirectory: "C:\\Program Files\\Bacula\\working"
-PluginDirectory: "C:\\Program Files\\Bacula\\plugins"
+WorkingDirectory: '"C:\\\Program Files\\\Bacula\\\working"'
+PidDirectory: '"C:\\\Program Files\\\Bacula\\\working"'
+PluginDirectory: '"C:\\\Program Files\\\Bacula\\\plugins"'


### PR DESCRIPTION
Add scape for / and " in jinja2.
When importing the file and when starting the service, error 1067.
The copied file looks like this:
FileDaemon {
  Name = bacula-server-fd
  FDport = 9102
  WorkingDirectory = C:\Program Files\Bacula\working
  Pid Directory = C:\Program Files\Bacula\working
  Plugin Directory = C:\Program Files\Bacula\plugins
  Maximum Concurrent Jobs = 20
}

For the service to be started it must be like this:
FileDaemon {
  Name = bacula-server-fd
  FDport = 9102
  WorkingDirectory = "C:\\Program Files\\Bacula\\working"
  Pid Directory = "C:\\Program Files\\Bacula\\working"
  Plugin Directory = "C:\\Program Files\\Bacula\\plugins"
  Maximum Concurrent Jobs = 20
}